### PR TITLE
error: ‘struct sockaddr’ has no member named ‘sa_len’

### DIFF
--- a/src/GEL/GLGraphics/Console.cpp
+++ b/src/GEL/GLGraphics/Console.cpp
@@ -618,7 +618,7 @@ void Console::open_socket() {
     sockaddr sck_addr;
     sck_addr.sa_family = AF_LOCAL;
     memcpy(sck_addr.sa_data, addr.c_str(), addr.length());
-#ifndef NOT_HAVE_SA_LEN
+#ifndef __GNUC__
     sck_addr.sa_len = addr.length();
 #endif
     if(bind(sck, &sck_addr, sizeof(sockaddr)) != 0) {


### PR DESCRIPTION
Reverting to __GNUC__
For more info see:
https://stackoverflow.com/questions/7581782/compiling-mdnsresponder-for-linux
https://opensource.apple.com/source/mDNSResponder/mDNSResponder-214/mDNSPosix/mDNSUNP.h.auto.html