### PR TITLE
Increase required CMake version to 11 for FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.11)
 project(GEL)
 find_package(Threads)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
The minimum CMake version is too low for the FetchContent module, which was introduced in CMake 11. As a result, the FetchContent_Declare macro fails ungracefully/opaquely if run by users with outdated versions of CMake.