### PR TITLE
CMake with include and library update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,14 @@ else ()
     target_link_libraries(PyGEL GEL)
 endif ()
 
+install(TARGETS GEL)
+
 install(TARGETS PyGEL GEL
         LIBRARY DESTINATION PyGEL
         ARCHIVE DESTINATION PyGEL)
 
+# Install Header Files
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/GEL
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h"
+    )

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Since GEL is primarily developed on Mac OS, the Xcode projects are actively main
 ### Building with CMake
 If you are using a unix-like command line, build with
 ```
-mkdir build; cd build; cmake ..; make -j 8 ; cd ..
+mkdir build; cd build; cmake ..; make -j 8 ; sudo make install; cd ..
 ```
 ### Creating a PyGEL3D package and installing it
 You can next issue the command


### PR DESCRIPTION
CMake now creates usr include and libraries when installed with `make install`. Readme updated accordingly.

- Headers in: /usr/local/include/GEL
- C++ Library in: /usr/local/lib/