### PR TITLE
Timfelle patch cmake includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,7 @@ else ()
 endif ()
 
 
-target_include_directories(GEL PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE src)
+target_include_directories(GEL PUBLIC ./src)
 aux_source_directory(./src/PyGEL PYG_SRC_LIST)
 
 if (Use_GLGraphics)
@@ -87,10 +84,7 @@ else ()
     target_link_libraries(PyGEL GEL)
 endif ()
 
-target_include_directories(PyGEL PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE src)
+target_include_directories(PyGEL PUBLIC ./src)
     
 install(TARGETS GEL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,14 @@ else ()
 endif ()
 
 
-include_directories(./src)
+target_include_directories(GEL PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+    PRIVATE src)
+target_include_directories(PyGEL PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+    PRIVATE src)
 aux_source_directory(./src/PyGEL PYG_SRC_LIST)
 
 if (Use_GLGraphics)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,6 @@ target_include_directories(GEL PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include>
     PRIVATE src)
-target_include_directories(PyGEL PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:include>
-    PRIVATE src)
 aux_source_directory(./src/PyGEL PYG_SRC_LIST)
 
 if (Use_GLGraphics)
@@ -91,6 +87,11 @@ else ()
     target_link_libraries(PyGEL GEL)
 endif ()
 
+target_include_directories(PyGEL PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+    PRIVATE src)
+    
 install(TARGETS GEL)
 
 install(TARGETS PyGEL GEL


### PR DESCRIPTION
Include directories was not set for the GEL and PyGEL targets. This caused libraries depending on GEL to manually configure inclusion of the GEL headers.

This change remidies that by defining public include directories for the libraries GEL and PyGEL