### PR TITLE
Add automated testing

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/GEL
     FILES_MATCHING PATTERN "*.h"
     )
 
+# Add test projects
+include(CTest)
+add_subdirectory(src/test)
 
 # No install instructions for PyGEL. It is left in the build directory and
 # included in the wheel package.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,13 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/GEL
     )
 
 # Add test projects
-include(CTest)
-add_subdirectory(src/test)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(CTest)
+endif()
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+    add_subdirectory(src/test)
+endif()
+
 
 # No install instructions for PyGEL. It is left in the build directory and
 # included in the wheel package.

--- a/src/test/CGLA-covariance/CMakeLists.txt
+++ b/src/test/CGLA-covariance/CMakeLists.txt
@@ -1,10 +1,15 @@
 cmake_minimum_required(VERSION 3.30)
-project(CGLA-covarianceGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
+project(GEL.Test.CGLA-covariance)
 
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
+# Locate the GEL library if invoked from here
+if(NOT GEL)
+    find_library(GEL PATHS ../../../build GEL_PATH)
+endif()
 
 add_executable(covariance_test covariance_test.cpp)
-target_link_libraries(covariance_test ${GEL_LIB})
+target_include_directories(covariance_test PRIVATE ../..)
+set_target_properties(covariance_test PROPERTIES
+CXX_STANDARD 20)
+
+target_link_libraries(covariance_test GEL)
+add_test(NAME GEL.Test.CGLA-covariance COMMAND covariance_test)

--- a/src/test/CGLA-covariance/CMakeLists.txt
+++ b/src/test/CGLA-covariance/CMakeLists.txt
@@ -1,15 +1,8 @@
 cmake_minimum_required(VERSION 3.30)
-project(GEL.Test.CGLA-covariance)
-
-# Locate the GEL library if invoked from here
-if(NOT GEL)
-    find_library(GEL PATHS ../../../build GEL_PATH)
-endif()
 
 add_executable(covariance_test covariance_test.cpp)
 target_include_directories(covariance_test PRIVATE ../..)
-set_target_properties(covariance_test PROPERTIES
-CXX_STANDARD 20)
-
+set_target_properties(covariance_test PROPERTIES CXX_STANDARD 20)
 target_link_libraries(covariance_test GEL)
+
 add_test(NAME GEL.Test.CGLA-covariance COMMAND covariance_test)

--- a/src/test/CGLA-mat/CMakeLists.txt
+++ b/src/test/CGLA-mat/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.30)
-project(CGLA-covarianceGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
-
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
 
 add_executable(mat_test mat_test.cpp)
-target_link_libraries(mat_test ${GEL_LIB})
+target_include_directories(mat_test PRIVATE ../..)
+set_target_properties(covariance_test PROPERTIES CXX_STANDARD 20)
+target_link_libraries(mat_test GEL)
+
+add_test(NAME GEL.Test.CGLA-mat COMMAND mat_test)

--- a/src/test/CGLA-ogl/CMakeLists.txt
+++ b/src/test/CGLA-ogl/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.30)
-project(OGL-testGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
+
 find_package (OpenGL REQUIRED)
 find_package (GLUT REQUIRED)
 
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
-
 add_executable(ogl_test ogl_test.cpp)
-target_link_libraries(ogl_test ${GEL_LIB} OpenGL::GL OpenGL::GLU GLUT::GLUT)
+target_include_directories(ogl_test PRIVATE ../..)
+set_target_properties(ogl_test PROPERTIES CXX_STANDARD 20)
+target_link_libraries(ogl_test GEL OpenGL::GL OpenGL::GLU GLUT::GLUT)
+
+add_test(NAME GEL.Test.CGLA-OGL COMMAND ogl_test)

--- a/src/test/CGLA-simple/CMakeLists.txt
+++ b/src/test/CGLA-simple/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.30)
-project(CGLA-covarianceGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
-
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
 
 add_executable(simple_test simple_test.cpp)
-target_link_libraries(simple_test ${GEL_LIB})
+target_include_directories(simple_test PRIVATE ../..)
+set_target_properties(simple_test PROPERTIES CXX_STANDARD 20)
+target_link_libraries(simple_test GEL)
+
+add_test(NAME GEL.Test.CGLA-simple COMMAND simple_test)

--- a/src/test/CGLA-vec/CMakeLists.txt
+++ b/src/test/CGLA-vec/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.30)
-project(CGLA-vecGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
-
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
 
 add_executable(vec_test vec_test.cpp)
-target_link_libraries(vec_test ${GEL_LIB})
+target_include_directories(vec_test PRIVATE ../..)
+set_target_properties(vec_test PROPERTIES CXX_STANDARD 20)
+target_link_libraries(vec_test GEL)
+
+add_test(NAME GEL.Test.CGLA-vec COMMAND vec_test)
+

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,15 +1,10 @@
 cmake_minimum_required(VERSION 3.30)
-project(GELtest)
-
-# Locate the GEL library if invoked from here
-if(NOT GEL)
-    find_library(GEL PATHS ../../../build GEL_PATH)
-endif()
 
 add_subdirectory(CGLA-covariance)
-#add_subdirectory(CGLA-mat)
+add_subdirectory(CGLA-mat)
+add_subdirectory(CGLA-simple)
+add_subdirectory(CGLA-vec)
+add_subdirectory(Geometry-kdtree)
+# The following two rely on key input in order to exit
 #add_subdirectory(CGLA-ogl)
-#add_subdirectory(CGLA-simple)
-#add_subdirectory(CGLA-vec)
-#add_subdirectory(Geometry-kdtree)
 #add_subdirectory(GLGraphics-console)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.30)
+project(GELtest)
+
+# Locate the GEL library if invoked from here
+if(NOT GEL)
+    find_library(GEL PATHS ../../../build GEL_PATH)
+endif()
+
+add_subdirectory(CGLA-covariance)
+#add_subdirectory(CGLA-mat)
+#add_subdirectory(CGLA-ogl)
+#add_subdirectory(CGLA-simple)
+#add_subdirectory(CGLA-vec)
+#add_subdirectory(Geometry-kdtree)
+#add_subdirectory(GLGraphics-console)

--- a/src/test/GLGraphics-console/CMakeLists.txt
+++ b/src/test/GLGraphics-console/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.30)
-project(GLGraphics-consoleGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
+
 find_package (OpenGL REQUIRED)
 find_package (GLUT REQUIRED)
 
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
-
 add_executable(console_test console_test.cpp)
-target_link_libraries(console_test ${GEL_LIB} OpenGL::GL OpenGL::GLU GLUT::GLUT)
+target_include_directories(console_test PRIVATE ../..)
+set_target_properties(console_test PROPERTIES CXX_STANDARD 20)
+target_link_libraries(console_test GEL OpenGL::GL OpenGL::GLU GLUT::GLUT)
+
+add_test(NAME GEL.Test.GLGraphics-console COMMAND console_test)

--- a/src/test/Geometry-kdtree/CMakeLists.txt
+++ b/src/test/Geometry-kdtree/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.30)
-project(CGLA-covarianceGEL)
-set(CMAKE_CXX_STANDARD 20)
-include_directories(../..)
-
-# Locate the GEL library
-find_library(GEL_LIB GEL PATHS ../../../../build)
 
 add_executable(kdtree-test kdtree-test.cpp)
-target_link_libraries(kdtree-test ${GEL_LIB})
+target_include_directories(kdtree-test PRIVATE ../..)
+set_target_properties(kdtree-test PROPERTIES CXX_STANDARD 20)
+target_link_libraries(kdtree-test GEL)
+
+add_test(NAME GEL.Test.Geometry-kdtree COMMAND kdtree-test)


### PR DESCRIPTION
Solves #81.

This pull request modifies the CMakeLists files to include some of the projects in the src/test directory as tests from the main CMakeLists.txt file. The two OpenGL projects are not included since they spawn a window that must manually be closed (and the CI would likely need some changes to attach to a dummy GL device and window).

Other things to do:

- Add a testing framework as a dev dependency. Google Test is likely severely overkill. Something like https://github.com/doctest/doctest might be a good choice, having a single header. 
- Modify the existing test files so that they actually perform assertions and return a non zero value on failure.
- Move things that should be in the example folder to there.
- Add further tests for increased coverage.