### PR TITLE
reset static values

### DIFF
--- a/src/GEL/HMesh/RsR.cpp
+++ b/src/GEL/HMesh/RsR.cpp
@@ -2207,6 +2207,25 @@ void build_mst(SimpGraph& g, NodeID root,
     return;
 }
 
+void reset_static() {
+    isGTNormal = true;
+    isEuclidean = true;
+    isFaceLoop = true;
+    isDebug = false;
+    isNoiseExperiment = false;
+    k = 30;
+    r = 20.;
+    theta = 60.;
+    step_thresh = 50;
+    exp_genus = -1;
+    model_path = "";
+    root_path = "";
+    model_name = "";
+    mode = "";
+    recon_timer = RsR_Timer();
+    bettiNum_1 = 0;
+}
+
 
 void reconstruct_single(HMesh::Manifold& output, std::vector<Point>& org_vertices,
     std::vector<Vector>& org_normals, bool in_isEuclidean, int in_genus, 
@@ -2476,6 +2495,7 @@ void reconstruct_single(HMesh::Manifold& output, std::vector<Point>& org_vertice
     std::string line(40, '=');
     std::cout << line << std::endl << std::endl;
     recon_timer.show();
+    reset_static();
 
     return;
 }

--- a/src/GEL/HMesh/RsR.h
+++ b/src/GEL/HMesh/RsR.h
@@ -383,6 +383,8 @@ bool isIntersecting(RSGraph& mst, NodeID v1,
 
 bool routine_check(RSGraph& mst, std::vector<NodeID>& triangle);
 
+void reset_static();
+
 /**
  * @brief Reconstructs a single mesh manifold from input points and normals.
  *


### PR DESCRIPTION
Hi Andreas,

The C++ demo got a different reconstructed A because I defined some static values. In the C++ demo, we firstly reconstruct the owl, which is a model that needs to estimate normal, after that we didn't reset some static values, causing the second reconstruction to still estimate the normal instead of using the normal we provide. In this version, I did a quick fix to reset those static values every time after finishing one reconstruction. But maybe you don't want those static values (also it is not in any namespace I guess), then we can talk about it later :D

Cheers,
Ruiqi