### PR TITLE
Manifold Improvements

### DIFF
--- a/src/GEL/HMesh/AttributeVector.h
+++ b/src/GEL/HMesh/AttributeVector.h
@@ -13,11 +13,8 @@
 #ifndef __HMESH_ATTRIBUTEVECTOR_H__
 #define __HMESH_ATTRIBUTEVECTOR_H__
 
-#include <cassert>
-#include <vector>
-#include <map>
+#include <GEL/HMesh/ConnectivityKernel.h>
 #include <GEL/Util/AttribVec.h>
-#include <GEL/Util/Serialization.h>
 
 namespace HMesh 
 {

--- a/src/GEL/HMesh/Circulators.h
+++ b/src/GEL/HMesh/Circulators.h
@@ -18,11 +18,14 @@ namespace HMesh {
 
     template<typename  ITEM>
     class VertexCirculator {
-        const ConnectivityKernel* ck;
+        const ConnectivityKernel* ck = nullptr;
         HalfEdgeID he;
-        bool begun;
+        bool begun = false;
     public:
         using value_type = ItemID<ITEM>;
+        using difference_type = ptrdiff_t;
+
+        VertexCirculator() = default;
 
         VertexCirculator(const ConnectivityKernel& _ck, HalfEdgeID _he, bool _begun=false):
             ck(&_ck), he(_he), begun(_begun) {}
@@ -55,6 +58,7 @@ namespace HMesh {
             return false;
         }
     };
+    static_assert(std::input_iterator<VertexCirculator<Face>>);
 
     template<>
     inline VertexCirculator<Vertex>::value_type VertexCirculator<Vertex>::operator*() const {
@@ -80,6 +84,9 @@ namespace HMesh {
         bool begun;
     public:
         using value_type = ItemID<ITEM>;
+        using difference_type = ptrdiff_t;
+
+        FaceCirculator() = default;
 
         FaceCirculator(const ConnectivityKernel& _ck, HalfEdgeID _he, bool _begun=false):
             ck(&_ck), he(_he), begun(_begun) {}
@@ -112,6 +119,7 @@ namespace HMesh {
             return false;
         }
     };
+    static_assert(std::input_iterator<FaceCirculator<Face>>);
 
     template<>
     inline FaceCirculator<Vertex>::value_type FaceCirculator<Vertex>::operator*() const {
@@ -132,4 +140,4 @@ namespace HMesh {
 }
 
 
-#endif /* Circulator_h */
+#endif /* HMesh_Circulators_h */

--- a/src/GEL/HMesh/Manifold.cpp
+++ b/src/GEL/HMesh/Manifold.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#include <ranges>
 #include <stack>
 
 #include <GEL/Geometry/TriMesh.h>
@@ -24,54 +25,7 @@ namespace HMesh
     /*********************************************
 	 * Public functions
 	 *********************************************/
-    
-    FaceID Manifold::add_face(const std::vector<Manifold::Vec>& points)
-    {
-        struct Edge
-        {
-            HalfEdgeID h0 = InvalidHalfEdgeID;
-            HalfEdgeID h1 = InvalidHalfEdgeID;
-            int count;
-        };
 
-        int N = points.size();
-        vector<VertexID> vertices(N);
-        for(size_t i=0;i<points.size(); ++i) {
-            vertices[i]=kernel.add_vertex();
-            pos(vertices[i]) = points[i];
-        }
-        vector<Edge> edges(N);
-        for(size_t i=0;i<N; ++i) {
-            VertexID v0 = vertices[i];
-            VertexID v1 = vertices[(i+1)%points.size()];
-
-            Edge& e = edges[i];
-            e.h0 = kernel.add_halfedge();
-            e.h1 = kernel.add_halfedge();
-            e.count = 1;
-            
-            // glue operation: 1 edge = 2 glued halfedges
-            glue(e.h0, e.h1);
-            
-            // update halfedges with the vertices they point to
-            kernel.set_vert(e.h0, v1);
-            kernel.set_vert(e.h1, v0);
-
-            kernel.set_out(vertices[(i+1)%N], edges[i].h1);
-        }
-
-        FaceID fid = kernel.add_face();
-        for(size_t i=0;i<N; ++i) {
-            kernel.set_face(edges[i].h0, fid);
-            kernel.set_face(edges[i].h1, InvalidFaceID);
-            link(edges[i].h0,edges[(i+1)%N].h0);
-            link(edges[(i+1)%N].h1,edges[i].h1);
-        }
-        kernel.set_last(fid, edges[N-1].h0);
-        
-        return fid;
-    }
-    
     bool Manifold::remove_face(FaceID fid)
     {
         if(!in_use(fid))

--- a/src/GEL/HMesh/Manifold.cpp
+++ b/src/GEL/HMesh/Manifold.cpp
@@ -99,10 +99,10 @@ namespace HMesh
             return false;
     
         vector<FaceID> faces;
-        circulate_vertex_ccw(*this, vid, static_cast<std::function<void(FaceID)>>([&](FaceID f) {
+        circulate_vertex_ccw(*this, vid, [&](FaceID f) {
             if(in_use(f))
                 faces.push_back(f);
-        }));
+        });
         for(auto f: faces)
             remove_face(f);
 
@@ -341,15 +341,15 @@ namespace HMesh
     {
         // get the one-ring of v0
         vector<VertexID> link0;
-        circulate_vertex_ccw(m, v0, static_cast<std::function<void(VertexID)>>([&](VertexID vn) {
+        circulate_vertex_ccw(m, v0, [&](VertexID vn) {
             link0.emplace_back(vn);
-        }));
+        });
 		
         // get the one-ring of v1
         vector<VertexID> link1;
-        circulate_vertex_ccw(m, v1, static_cast<std::function<void(VertexID)>>([&](VertexID vn) {
+        circulate_vertex_ccw(m, v1, [&](VertexID vn) {
             link1.emplace_back(vn);
-        }));
+        });
 		
         // sort the vertices of the two rings
         sort(link0.begin(), link0.end());
@@ -415,14 +415,14 @@ namespace HMesh
             }
 
             if(v0b != v0a)
-                circulate_vertex_ccw(*this, v0b, static_cast<std::function<void(Walker&)>>([&](Walker& hew) {
+                circulate_vertex_ccw(*this, v0b, [&](Walker& hew) {
                     kernel.set_vert(hew.opp().halfedge(), v0a);
-                }));
+                });
             
             if(v1b != v1a)
-                circulate_vertex_ccw(*this, v1b, static_cast<std::function<void(Walker&)>>([&](Walker& hew) {
+                circulate_vertex_ccw(*this, v1b, [&](Walker& hew) {
                     kernel.set_vert(hew.opp().halfedge(), v1a);
-                }));
+                });
             
             if(v0a != v0b)
             {
@@ -1442,27 +1442,27 @@ namespace HMesh
     
     Manifold::Vec Manifold::area_normal(FaceID f) const
     {
-        vector<Vec> v;
+        std::vector<Manifold::Vec> vertices;
         Vec c(0.0);
-        int k= circulate_face_ccw(*this, f, static_cast<std::function<void(VertexID)>>([&](VertexID vid) {
+        int k = circulate_face_ccw(*this, f, [&](VertexID vid) {
             Vec p = positions[vid];
             c += p;
-            v.push_back(p);
-        }));
+            vertices.push_back(p);
+        });
         c /= k;
         Manifold::Vec norm(0);
         for(int i=0;i<k;++i)
-            norm += cross(v[i]-c,v[(i+1)%k]-c);
+            norm += cross(vertices[i]-c,vertices[(i+1)%k]-c);
         return 0.5 * norm;
     }
     
     double Manifold::area(FaceID fid) const
     {
         // Get all projected vertices
-        vector<Manifold::Vec> vertices;
-        int N = circulate_face_ccw(*this, fid, static_cast<std::function<void(VertexID)>>([&](VertexID vid) {
+        std::vector<Manifold::Vec> vertices;
+        int N = circulate_face_ccw(*this, fid, [&](VertexID vid) {
             vertices.push_back(positions[vid]);
-        }));
+        });
         
         double area = 0;
         Manifold::Vec norm = normal(fid);

--- a/src/GEL/HMesh/Manifold.h
+++ b/src/GEL/HMesh/Manifold.h
@@ -741,156 +741,236 @@ namespace HMesh
     /// @return number of boundary curves
     int count_boundary_curves(const HMesh::Manifold& m);
 
-    /// @brief Circulate around a vertex in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a Walker as argument. Called once for each outgoing edge from v
+    /// @brief Circulate around a vertex in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_vertex_ccw(m, v, [&](Walker& w){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a Walker as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_ccw(const Manifold& m, VertexID v, std::function<void(Walker&)> f) {
+    template<typename Func> int circulate_vertex_ccw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, Walker&>
+    {
         Walker w = m.walker(v);
-        for(; !w.full_circle(); w = w.circulate_vertex_ccw()) f(w);
+        for (; !w.full_circle(); w = w.circulate_vertex_ccw()) f(w);
         return w.no_steps();
     }
-    
-    /// @brief Circulate around a vertex in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a VertexID as argument. Called once for each outgoing edge from v
-    /// @return number of steps taken.
-    inline int circulate_vertex_ccw(const Manifold& m, VertexID v, std::function<void(VertexID)> f) {
-        return circulate_vertex_ccw(m, v, static_cast<std::function<void(Walker&)>>([&](Walker& w){f(w.vertex());}));
-    }
 
     /// @brief Circulate around a vertex in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a FaceID as argument. Called once for each outgoing edge from v
+    /// @code{.cpp}
+    /// circulate_vertex_ccw(m, v, [&](VertexID vid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a VertexID as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_ccw(const Manifold& m, VertexID v, std::function<void(FaceID)> f) {
-        return circulate_vertex_ccw(m, v, static_cast<std::function<void(Walker&)>>([&](Walker& w){f(w.face());}));
+    template<typename Func> int circulate_vertex_ccw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, VertexID>
+    {
+        return circulate_vertex_ccw(m, v, [&](const Walker& w) { f(w.vertex()); });
     }
 
-    /// @brief Circulate around a vertex in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a HalfEdgeID as argument. Called once for each outgoing edge from v
+    /// @brief Circulate around a vertex in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_vertex_ccw(m, v, [&](FaceID fid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a FaceID as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_ccw(const Manifold& m, VertexID v, std::function<void(HalfEdgeID)> f) {
-        return circulate_vertex_ccw(m, v, static_cast<std::function<void(Walker&)>>([&](Walker& w){f(w.halfedge());}));
+    template<typename Func> int circulate_vertex_ccw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, FaceID>
+    {
+        return circulate_vertex_ccw(m, v, ([&](const Walker& w) { f(w.face()); }));
     }
-    
+
+    /// @brief Circulate around a vertex in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_vertex_ccw(m, v, [&](HalfEdgeID hid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a HalfEdgeID as an argument. Called once for each outgoing edge from v.
+    /// @return number of steps taken.
+    template<typename Func> int circulate_vertex_ccw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, HalfEdgeID>
+    {
+        return circulate_vertex_ccw(m, v, [&](const Walker& w) { f(w.halfedge()); });
+    }
+
     /// @brief Circulate around a vertex in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a Walker as argument. Called once for each outgoing edge from v
+    /// @code{.cpp}
+    /// circulate_vertex_cw(m, v, [&](Walker& w){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a Walker as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_cw(const Manifold& m, VertexID v, std::function<void(Walker&)> f) {
+    template<typename Func> int circulate_vertex_cw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, Walker&>
+    {
         Walker w = m.walker(v);
-        for(; !w.full_circle(); w = w.circulate_vertex_cw()) f(w);
+        for (; !w.full_circle(); w = w.circulate_vertex_cw()) f(w);
         return w.no_steps();
     }
 
     /// @brief Circulate around a vertex in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a VertexID as argument. Called once for each outgoing edge from v
+    /// @code{.cpp}
+    /// circulate_vertex_cw(m, v, [&](VertexID vid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a VertexID as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_cw(const Manifold& m, VertexID v, std::function<void(VertexID)> f) {
-        return circulate_vertex_cw(m, v, static_cast<std::function<void(Walker&)>>([&](Walker& w){f(w.vertex());}));
+    template<typename Func> int circulate_vertex_cw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, VertexID>
+    {
+        return circulate_vertex_cw(m, v, [&](const Walker& w) { f(w.vertex()); });
     }
 
     /// @brief Circulate around a vertex in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a FaceID as argument. Called once for each outgoing edge from v
+    /// @code{.cpp}
+    /// circulate_vertex_cw(m, v, [&](FaceID fid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a FaceID as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_cw(const Manifold& m, VertexID v, std::function<void(FaceID)> f) {
-        return circulate_vertex_cw(m, v, static_cast<std::function<void(Walker&)>>([&](Walker& w){f(w.face());}));
+    template<typename Func> int circulate_vertex_cw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, FaceID>
+    {
+        return circulate_vertex_cw(m, v, [&](const Walker& w) { f(w.face()); });
     }
-
 
     /// @brief Circulate around a vertex in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param v is the vertex to circulate around.
-    /// @param f is a function that takes a HalfEdgeID as argument. Called once for each outgoing edge from v
+    /// @code{.cpp}
+    /// circulate_vertex_cw(m, v, [&](HalfEdgeID hid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param v The vertex to circulate around.
+    /// @param f A function that takes a HalfEdgeID as an argument. Called once for each outgoing edge from v.
     /// @return number of steps taken.
-    inline int circulate_vertex_cw(const Manifold& m, VertexID v, std::function<void(HalfEdgeID)> f) {
-        return circulate_vertex_cw(m, v, static_cast<std::function<void(Walker&)>>([&](Walker& w){f(w.halfedge());}));
+    template<typename Func> int circulate_vertex_cw(const Manifold& m, VertexID v, Func&& f)
+    requires std::is_invocable_v<Func, HalfEdgeID>
+    {
+        return circulate_vertex_cw(m, v, [&](const Walker& w) { f(w.halfedge()); });
     }
-    
-    /// @brief Circulate a face in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a Walker as argument. Called once for each edge of f
+
+    /// @brief Circulate a face in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_face_ccw(m, f, [&](Walker& w){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a Walker as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_ccw(const Manifold& m, FaceID f, std::function<void(Walker&)> g) {
+    template<typename Func> int circulate_face_ccw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, Walker&>
+    {
         Walker w = m.walker(f);
-        for(; !w.full_circle(); w = w.circulate_face_ccw()) g(w);
+        for (; !w.full_circle(); w = w.circulate_face_ccw()) g(w);
         return w.no_steps();
     }
 
-    /// @brief Circulate a face in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a VertexID as argument. Called once for each edge of f
+    /// @brief Circulate a face in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_face_ccw(m, f, [&](VertexID vid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a VertexID as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_ccw(const Manifold& m, FaceID f, std::function<void(VertexID)> g) {
-        return circulate_face_ccw(m, f, static_cast<std::function<void(Walker&)>>([&](Walker& w){g(w.vertex());}));
+    template<typename Func>
+    int circulate_face_ccw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, VertexID>
+    {
+        return circulate_face_ccw(m, f, [&](Walker& w) { g(w.vertex()); });
     }
 
-    /// @brief Circulate a face in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a FaceID as argument. Called once for each edge of f
+    /// @brief Circulate a face in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_face_ccw(m, f, [&](FaceID fid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a FaceID as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_ccw(const Manifold& m, FaceID f, std::function<void(FaceID)> g) {
-        return circulate_face_ccw(m, f, static_cast<std::function<void(Walker&)>>([&](Walker& w){g(w.opp().face());}));
+    template<typename Func> int circulate_face_ccw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, FaceID>
+    {
+        return circulate_face_ccw(m, f, [&](Walker& w) { g(w.opp().face()); });
     }
 
-    /// @brief Circulate a face in counter clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a HalfEdgeID as argument. Called once for each edge of f
+    /// @brief Circulate a face in counter-clockwise order.
+    /// @code{.cpp}
+    /// circulate_face_ccw(m, f, [&](HalfEdgeID hid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a HalfEdgeID as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_ccw(const Manifold& m, FaceID f, std::function<void(HalfEdgeID)> g) {
-        return circulate_face_ccw(m, f, static_cast<std::function<void(Walker&)>>([&](Walker& w){g(w.halfedge());}));
+    template<typename Func> int circulate_face_ccw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, HalfEdgeID>
+    {
+        return circulate_face_ccw(m, f, [&](Walker& w) { g(w.halfedge()); });
     }
-    
+
     /// @brief Circulate a face in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a Walker as argument. Called once for each edge of f
+    /// @code{.cpp}
+    /// circulate_face_cw(m, f, [&](Walker& w){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a Walker as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_cw(const Manifold& m, FaceID f, std::function<void(Walker&)> g) {
+    template<typename Func> int circulate_face_cw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, Walker&>
+    {
         Walker w = m.walker(f);
-        for(; !w.full_circle(); w = w.circulate_face_cw()) g(w);
+        for (; !w.full_circle(); w = w.circulate_face_cw()) g(w);
         return w.no_steps();
     }
 
     /// @brief Circulate a face in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a VertexID as argument. Called once for each edge of f
+    /// @code{.cpp}
+    /// circulate_face_cw(m, f, [&](VertexID vid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a VertexID as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_cw(const Manifold& m, FaceID f, std::function<void(VertexID)> g) {
-        return circulate_face_cw(m, f, static_cast<std::function<void(Walker&)>>([&](Walker& w){g(w.vertex());}));
-    }
-
-     /// @brief Circulate a face in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a FaceID as argument. Called once for each edge of f
-    /// @return number of steps taken.   
-    inline int circulate_face_cw(const Manifold& m, FaceID f, std::function<void(FaceID)> g) {
-        return circulate_face_cw(m, f, static_cast<std::function<void(Walker&)>>([&](Walker& w){g(w.opp().face());}));
+    template<typename Func> int circulate_face_cw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, VertexID>
+    {
+        return circulate_face_cw(m, f, [&](Walker& w) { g(w.vertex()); });
     }
 
     /// @brief Circulate a face in clockwise order.
-    /// @param m is the manifold to circulate in.
-    /// @param f is the face to circulate around.
-    /// @param g is a function that takes a HalfEdgeID as argument. Called once for each edge of f
+    /// @code{.cpp}
+    /// circulate_face_cw(m, f, [&](FaceID fid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a FaceID as an argument. Called once for each edge of f.
     /// @return number of steps taken.
-    inline int circulate_face_cw(const Manifold& m, FaceID f, std::function<void(HalfEdgeID)> g) {
-        return circulate_face_cw(m, f, static_cast<std::function<void(Walker&)>>([&](Walker& w){g(w.halfedge());}));
+    template<typename Func> int circulate_face_cw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, FaceID>
+    {
+        return circulate_face_cw(m, f, [&](Walker& w) { g(w.opp().face()); });
+    }
+
+    /// @brief Circulate a face in clockwise order.
+    /// @code{.cpp}
+    /// circulate_face_cw(m, f, [&](HalfEdgeID hid){ });
+    /// @endcode
+    /// @param m The manifold to circulate in.
+    /// @param f The face to circulate around.
+    /// @param g A function that takes a HalfEdgeID as an argument. Called once for each edge of f.
+    /// @return number of steps taken.
+    template<typename Func> int circulate_face_cw(const Manifold& m, FaceID f, Func&& g)
+    requires std::is_invocable_v<Func, HalfEdgeID>
+    {
+        return circulate_face_cw(m, f, [&](Walker& w) { g(w.halfedge()); });
     }
 }

--- a/src/GEL/HMesh/Manifold.h
+++ b/src/GEL/HMesh/Manifold.h
@@ -651,7 +651,37 @@ namespace HMesh
     }
 
     // End of inline functions for the Manifold class  ---------------------------------
-    
+
+    /// @brief Build a manifold
+    /// @details Constructs a manifold from the given vertex and index spans. Returns a mapping from the manifold
+    /// indices to the original vertex indices.
+    /// If the provided input is not manifold, there will be failures during the stitching process.
+    /// @throws std::runtime_error If an entry in face_indexes is out of bounds.
+    /// @param manifold Manifold to build.
+    /// @param vertices A span of vertex coordinates.
+    /// @param face_indexes A span of vertex indexes for the faces in the manifold.
+    /// @param face_vert_count How many vertices each face contains. The sum of this span should be equal to the size of
+    /// face_indexes
+    /// @return Attribute vector containing a mapping from the manifold VertexIDs to original point indices
+    // TODO: should also return the number of failed stitches
+    VertexAttributeVector<size_t> build_manifold(Manifold& manifold, std::span<CGLA::Vec3d const> vertices,
+                                                 std::span<size_t const> face_indexes,
+                                                 std::span<int const> face_vert_count);
+
+    /// @brief Build a manifold where every face has the same number of vertices.
+    /// @details Constructs a manifold from the given vertex and index spans. Returns a mapping from the manifold
+    /// indices to the original vertex indices.
+    /// If the provided input is not manifold, there will be failures during the stitching process.
+    /// @throws std::runtime_error If an entry in face_indexes is out of bounds.
+    /// @param manifold manifold to build.
+    /// @param vertices a span of vertex coordinates.
+    /// @param face_indexes a span of vertex indices for the ngons in the manifold.
+    /// @param face_vert_count the number of vertices for every face.
+    /// @return Attribute vector containing a mapping from the manifold VertexIDs to original point indices
+    VertexAttributeVector<size_t> build_manifold(Manifold& manifold, std::span<CGLA::Vec3d const> vertices,
+        std::span<size_t const> face_indexes,
+        int face_vert_count);
+
     /** \brief Build a manifold.
      The arguments are the number of vertices (no_vertices),  the vector of vertices (vertvec),
      the number of faces (no_faces), a pointer to an array of float values (vert_vec) and an array

--- a/src/GEL/HMesh/Manifold.h
+++ b/src/GEL/HMesh/Manifold.h
@@ -309,9 +309,27 @@ namespace HMesh
         VertexID split_face_by_vertex(FaceID f);
        // VertexID split_face_by_vertex(HalfEdgeID h);
 
-        /** \brief Insert a new vertex on halfedge h.
-        The new halfedge is insterted as the previous edge to h.
-        A handle to the inserted vertex is returned. */
+        /// @brief Insert a new vertex on halfedge h.
+        ///
+        /// The new halfedge is inserted as the previous edge to h. (???)
+        /// A handle to the inserted vertex is returned.
+        ///
+        /// This is an Euler operation.
+        ///
+        /// We start with the following situation:
+        ///
+        /// v <- he ->                               <- heo -> vo
+        ///
+        /// We add a vertex in the middle:
+        ///
+        ///  v <- he ->               vn              <- heo -> vo
+        ///
+        /// Then we add two half edges from the vertex:
+        ///
+        ///  (v <- he ->) (<- heno -> vn <- hen ->)  (<- heo -> vo)
+        ///
+        ///  And then we add the new half-edges to existing faces.
+        ///  @return vertex introduced as a result of the edge splitting
         VertexID split_edge(HalfEdgeID h);
         
         /** \brief Stitch two halfedges.

--- a/src/GEL/HMesh/cleanup.cpp
+++ b/src/GEL/HMesh/cleanup.cpp
@@ -319,9 +319,7 @@ struct Corner {
         vector<int> faces;
         for(FaceID f: m.faces()) {
             faces.push_back(no_edges(m, f));
-			circulate_face_cw(m, f, static_cast<std::function<void(VertexID)>>([&](VertexID v){
-                indices.push_back(idvec[v]);
-            }));
+            circulate_face_cw(m, f, [&](VertexID v) { indices.push_back(idvec[v]); });
         }
         m.clear();
         build(m, vertices.size(), vertices[0].get(), faces.size(), &faces[0], &indices[0]);

--- a/src/GEL/HMesh/cleanup.h
+++ b/src/GEL/HMesh/cleanup.h
@@ -5,12 +5,12 @@
  * ----------------------------------------------------------------------- */
 
 /**
- * @file caps_and_needles.h
+ * @file cleanup.h
  * @brief Simple tools for improving polygonal meshes by removing bad triangles.
  */
 
-#ifndef __HMESH_CAPS_AND_NEEDLES_H__
-#define __HMESH_CAPS_AND_NEEDLES_H__
+#ifndef HMESH_CLEANUP_H
+#define HMESH_CLEANUP_H
 
 namespace HMesh
 {
@@ -26,15 +26,16 @@ namespace HMesh
     /** \brief Remove needles from a manifold consisting of only triangles.
     A needle is a triangle with a single very short edge. It is moved by collapsing the short edge. 
     The thresh parameter sets the length threshold as a fraction of the average edge length.		 */
-    void remove_needles(Manifold& m, float thresh=0.1f, bool averagePositions = true);
-    
-    /** \brief Stitch together edges whose endpoints coincide geometrically. 
+    void remove_needles(Manifold& m, float thresh = 0.1f, bool averagePositions = true);
+
+    /** \brief Stitch together edges whose endpoints coincide geometrically.
      This function allows you to create a mesh as a bunch of faces and then stitch these together
      to form a coherent whole. What this function adds is a spatial data structure to find out
      which vertices coincide. The return value is the number of edges that could not be stitched. 
      Often this is because it would introduce a non-manifold situation.*/
     int stitch_mesh(Manifold& m, double rad);
-    int stitch_mesh(Manifold& m, const VertexAttributeVector<int>& cluster_id);
+
+    template<typename Integral> Integral stitch_mesh(Manifold& m, const VertexAttributeVector<Integral>& cluster_id);
 
     /** \brief Stitches the mesh together, splits edges that could not be stitched and goes again.
      This function thereby handles situations where stitch mesh would not have worked. */
@@ -51,14 +52,14 @@ namespace HMesh
     void flip_orientation(Manifold& m);
     
     /** Remove valence one vertices. */
-    void remove_valence_one_vertices(Manifold & m);
+    void remove_valence_one_vertices(Manifold& m);
 
     /** Remove valence two vertices. */
-    void remove_valence_two_vertices(Manifold & m);
+    void remove_valence_two_vertices(Manifold& m);
 
     /** This function merges pairs of boundary vertices, provided there are exactly two such vertices
      at a given point in space, that they are not in each others' one ring and  that the one rings are disjoint. */
-    void merge_coincident_boundary_vertices(Manifold& m, double rad=1e-30);
-}
+    void merge_coincident_boundary_vertices(Manifold& m, double rad = 1e-30);
+} // namespace HMesh
 
 #endif

--- a/src/GEL/HMesh/face_loop.h
+++ b/src/GEL/HMesh/face_loop.h
@@ -10,7 +10,7 @@
 #define face_loop_hmesh
 
 #include <GEL/CGLA/CGLA.h>
-#include <GEL/HMesh/HMesh.h>
+#include <GEL/HMesh/Manifold.h>
 #include <GEL/Geometry/Graph.h>
 
 /** FaceLoop data structure. The face loop is represented in terms of halfedges which separate the faces of the loop.

--- a/src/GEL/HMesh/polygonize.cpp
+++ b/src/GEL/HMesh/polygonize.cpp
@@ -68,7 +68,7 @@ namespace  HMesh {
                             t = (tau-va)/(vb - va);
                         }
                         edge_intersections.push_back(p * (1-t) + Vec3d(pni) * t);
-                        vector<Vec3d> quad_vertices(4);
+                        std::array<Vec3d, 4> quad_vertices;
                         for(int n=0;n<4;++n)
                             quad_vertices[n] = p + hex_faces[nbr_idx][3-n];
                         mani.add_face(quad_vertices);

--- a/src/GEL/HMesh/quad_valencify.cpp
+++ b/src/GEL/HMesh/quad_valencify.cpp
@@ -536,10 +536,10 @@ void quad_valencify_cc(HMesh::Manifold& m_orig,
     
     Manifold m_dual;
     for (auto v: m.vertices()) {
-        vector<Vec3d> pos;
-        for (auto fn: m.incident_faces(v)) {
-            pos.push_back(centre(m,fn));
-        }
+        // add_face cannot be called with owned views
+        auto incident = m.incident_faces(v);
+        auto pos = std::views::all(incident)
+        | std::views::transform([&m](FaceID fn) { return centre(m, fn); });
         m_dual.add_face(pos);
     }
     stitch_mesh(m_dual,1e-10);

--- a/src/GEL/HMesh/skeleton_to_FEQ.cpp
+++ b/src/GEL/HMesh/skeleton_to_FEQ.cpp
@@ -102,7 +102,7 @@ void quad_mesh_leaves(HMesh::Manifold& m, VertexAttributeVector<NodeID>& vertex2
 
 vector<FaceID> create_face_pair(Manifold& m, const Vec3d& pos, const Mat3x3d& _R, int axis,
                                 Face2VertexMap& one_ring_face_vertex) {
-    int num_sides = 8;
+    constexpr int num_sides = 8;
     Mat3x3d R = _R;
     double det = determinant(R);
     if(abs(det) > 1e-6)
@@ -112,8 +112,8 @@ vector<FaceID> create_face_pair(Manifold& m, const Vec3d& pos, const Mat3x3d& _R
             R = R * M;
         }
 
-    vector<FaceID> fvec;
-    vector<Vec3d> pts;
+    std::vector<FaceID> fvec;
+    std::array<Vec3d, num_sides> pts;
     double angle = 0.0;
     for(int i = 0; i < num_sides; i++)
     {
@@ -123,10 +123,10 @@ vector<FaceID> create_face_pair(Manifold& m, const Vec3d& pos, const Mat3x3d& _R
         p[(0+axis)%3] += _p[0];
         p[(1+axis)%3] += _p[1];
         p[(2+axis)%3] += _p[2];
-        pts.push_back(R*p+pos);
+        pts[i] = R*p+pos;
     }
     fvec.push_back(m.add_face(pts));
-    reverse(begin(pts), end(pts));
+    std::ranges::reverse(pts);
     fvec.push_back(m.add_face(pts));
 
     for (auto f: fvec) 
@@ -456,10 +456,10 @@ construct_bnps(const Geometry::AMGraph3D &g,
             VertexAttributeVector<int> vertexid2spts;
             for (auto tri : stris)
             {
-                vector<Vec3d> triangle_pts;
-                for (int i = 0; i < 3; ++i)
+                std::array<Vec3d, 3> triangle_pts;
+                for (int i = 0; i < triangle_pts.size(); ++i)
                 {
-                    triangle_pts.push_back(spts[tri[i]]);
+                    triangle_pts[i] = spts[tri[i]];
                 }
                 FaceID f = m.add_face(triangle_pts);
                 int i=0;

--- a/src/GEL/HMesh/skeleton_to_FEQ.cpp
+++ b/src/GEL/HMesh/skeleton_to_FEQ.cpp
@@ -602,22 +602,20 @@ vector<pair<VertexID, VertexID>> face_match_one_ring(const HMesh::Manifold& m, F
     
     int count = 0;
     
-    circulate_face_ccw(m, f0, std::function<void(VertexID)>([&](VertexID v){
+    circulate_face_ccw(m, f0, [&](VertexID v) {
         loop0.push_back(v);
-        if(v == face_vertex_0)
-            loop0_index = count;
+        if (v == face_vertex_0) loop0_index = count;
         count++;
-    }) );
+    });
     
     vector<VertexID> loop1;
     count = 0;
     
-    circulate_face_ccw(m, f1, std::function<void(VertexID)>( [&](VertexID v) {
+    circulate_face_ccw(m, f1, [&](VertexID v) {
         loop1.push_back(v);
-        if(v == face_vertex_1)
-            loop1_index = count;
+        if (v == face_vertex_1) loop1_index = count;
         count++;
-    }) );
+    });
     
     size_t L0= loop0.size();
     size_t L1= loop1.size();

--- a/src/GEL/Util/Range.h
+++ b/src/GEL/Util/Range.h
@@ -9,15 +9,16 @@
 #ifndef NumericRange_h
 #define NumericRange_h
 
-#include <cstddef>
+#include <ranges>
 
 namespace Util {
+// FIXME: this just duplicates functionality of std::ranges::iota_view, consider deprecating it
     class Range {
     public:
         class iterator {
             friend class Range;
         public:
-            // typedefs to accommodiate stl compliance
+            // typedefs to accommodate stl compliance
             typedef ptrdiff_t difference_type;
             typedef std::forward_iterator_tag iterator_category;
             typedef long int value_type;
@@ -25,19 +26,21 @@ namespace Util {
             typedef value_type* pointer;
 
             value_type operator *() const { return i_; }
-            const iterator &operator ++() { ++i_; return *this; }
+            iterator &operator ++() { ++i_; return *this; }
             iterator operator ++(int) { iterator copy(*this); ++i_; return copy; }
-            
+
             bool operator ==(const iterator &other) const { return i_ == other.i_; }
             bool operator !=(const iterator &other) const { return i_ != other.i_; }
-            
+
+            // required for std::viewable_range
+            iterator() = default;
         protected:
             iterator(long int start) : i_ (start) { }
-            
+
         private:
             unsigned long i_;
         };
-        
+
         iterator begin() const { return begin_; }
         iterator end() const { return end_; }
         Range(long int  begin, long int end) : begin_(begin), end_(end) {}
@@ -45,6 +48,8 @@ namespace Util {
         iterator begin_;
         iterator end_;
     };
+    static_assert(std::input_or_output_iterator<Range::iterator>);
+    static_assert(std::ranges::viewable_range<const Range&>);
 }
 
 #endif /* NumericRange_h */

--- a/src/PyGEL/Manifold.cpp
+++ b/src/PyGEL/Manifold.cpp
@@ -161,11 +161,10 @@ size_t Manifold_circulate_face(Manifold_ptr _self, size_t _f, char mode, IntVect
 size_t Manifold_add_face(Manifold_ptr _self, size_t no_verts, double* pos) {
     Manifold* self = reinterpret_cast<Manifold*>(_self);
 
-    vector<Vec3d> pts(no_verts);
-    for(size_t i=0;i<no_verts;++i) {
-        auto v = Vec3d(pos[3*i],pos[3*i+1],pos[3*i+2]);
-        pts[i] = v;
-    }
+    auto pts = std::views::iota(0UL, no_verts) |
+        std::views::transform([pos](size_t i) {
+            return Vec3d(pos[3 * i], pos[3 * i + 1], pos[3 * i + 2]);
+        });
     FaceID f = self->add_face(pts);
     return f.get_index();
 }


### PR DESCRIPTION
This PR modernizes some parts of Manifold to improve some code. Particularly to get rid of unnecessary indirection, reduce some copying and get rid of some unneeded allocations. 

- [x] circulate functions made generic
- [x] zero-alloc add_face
- [x] modify certain internal data structures to comply with necessary std concepts
- [x] fix calls to circulate functions
- [x] fix calls to add_face
- [x] fix signature of stitch_mesh
- [x] add build_manifold to replace build family of functions
- [x] ~~deprecate build family of functions~~ 
 Too much of a testing burden, best moved to a different PR.
- [x] ~~Replace assert with GEL_ASSERT~~ (needs #87)
  - [x] Revert assert macros to use printf because GCC 11.4 doesn't support \<format\>
- [ ] add tests (see #90)

---

I might split this to multiple PRs if this is too much. 

--- 
This PR also solves #88, but I have not verified whether the updated function has the correct behavior.