### PR TITLE
Add nanobench and doctest

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,5 +1,32 @@
 cmake_minimum_required(VERSION 3.30)
 
+include(FetchContent)
+
+# Add benchmarking library
+FetchContent_Declare(
+    nanobench
+    GIT_REPOSITORY https://github.com/martinus/nanobench.git
+    GIT_TAG v4.1.0
+    GIT_SHALLOW TRUE)
+
+# Add testing library
+FetchContent_Declare(
+    doctest
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
+    GIT_TAG v2.4.12
+    GIT_SHALLOW TRUE)
+
+FetchContent_MakeAvailable(nanobench)
+# # Add nanobench to a project with:
+# target_link_libraries(some_executable nanobench)
+
+FetchContent_MakeAvailable(doctest)
+FetchContent_GetProperties(doctest SOURCE_DIR doctest_source_dir)
+set(DOCTEST_INCLUDE_DIR ${doctest_source_dir}/doctest CACHE INTERNAL "Path to include folder for doctest")
+# # Add doctest to a project with:
+# target_include_directories(some_executable PRIVATE ${DOCTEST_INCLUDE_DIR})
+include(${doctest_source_dir}/scripts/cmake/doctest.cmake)
+
 add_subdirectory(CGLA-covariance)
 add_subdirectory(CGLA-mat)
 add_subdirectory(CGLA-simple)


### PR DESCRIPTION
Adds development dependency for nanobench and doctest for benchmarking and testing. 

These are both minimal, single header libraries with no transitive dependencies that are actively maintained. They're integrated with CTest so they will directly show up on the CI.

Docs for nanobench: https://nanobench.ankerl.com/

Docs for doctest: https://github.com/doctest/doctest?tab=readme-ov-file

---

Some other alternatives were GoogleTest and Boost.Test which are overkill for GEL and Catch2 which doctest is actually forked from (although doctest is easier to include and is thread safe). However I'm happy with these two and think they would be good inclusions for testing the C++ library.

