### PR TITLE
Revert Assert.h to support GCC 11.4

### DIFF
--- a/src/GEL/Util/Assert.h
+++ b/src/GEL/Util/Assert.h
@@ -6,223 +6,198 @@
 #ifndef GEL_ASSERT_H
 #define GEL_ASSERT_H
 
+#include <cstdio>
 #include <sstream>
 #include <stdexcept>
-#include <format>
-#include <iterator>
 
 /// The assert macro in <cassert> is inert in release mode. Certain graph algorithms
 /// are very slow necessitating testing on release mode which is why these macros are
 /// provided.
-namespace Util::Assert::detail
-{
-template <typename T>
-concept has_to_str_operator =
-    requires(T t, std::stringstream& os)
-    {
+namespace Util::Assert::detail {
+    template<typename T> concept has_to_str_operator = requires(T t, std::stringstream& os) {
         { os << t };
     };
 
-template <typename Left, typename Right>
-concept has_eq =
-    requires(Left left, Right right)
-    {
+    template<typename Left, typename Right> concept has_eq = requires(Left left, Right right) {
         { left == right } -> std::same_as<bool>;
         { left != right } -> std::same_as<bool>;
     };
 
-template <typename T>
-std::string string_repr(T&& t)
+    template<typename T> std::string string_repr(T&& t)
     requires has_to_str_operator<T>
-{
-    std::stringstream ss;
-    ss << t;
-    return ss.str();
-}
-
-template <typename T>
-std::string string_repr(T&& t)
-{
-    return "?";
-}
-
-template <typename... Args>
-[[noreturn]]
-#ifdef _MSC_VER
-__declspec(noinline)
-#else
-__attribute__((noinline))
-#endif
-void gel_assert_failure(const char* file, const int line, auto func, const char* expr,
-                        std::format_string<Args...>&& fmt,
-                        Args&&... args)
-{
-    std::ostream_iterator<char> os(std::cerr);
-    std::format_to(os, "Assertion failed at {}:{} in `{}`\nBecause '{}' is false\n", file, line, func, expr);
-    std::format_to(os, fmt, std::forward<Args>(args)...);
-    std::format_to(os, "\n");
-    throw std::runtime_error("GEL assertion failure");
-}
-
-template <typename... Args>
-[[noreturn]]
-#ifdef _MSC_VER
-__declspec(noinline)
-#else
-__attribute__((noinline))
-#endif
-void gel_assert_false_failure(const char* file, const int line, auto func, const char* expr,
-                              std::format_string<Args...>&& fmt, Args&&... args)
-{
-    std::ostream_iterator<char> os(std::cerr);
-    std::format_to(os, "Assertion failed at {}:{} in `{}`\nBecause '{}' is true\n", file, line, func, expr);
-    std::format_to(os, fmt, std::forward<Args>(args)...);
-    std::format_to(os, "\n");
-    throw std::runtime_error("GEL assertion failure");
-}
-
-template <typename... Args>
-[[noreturn]]
-#ifdef _MSC_VER
-__declspec(noinline)
-#else
-__attribute__((noinline))
-#endif
-void gel_assert_eq_failure(
-    const char* file,
-    const int line,
-    const char* func,
-    const char* left,
-    const char* right,
-    auto left_value,
-    auto right_value,
-    std::format_string<Args...>&& fmt,
-    Args&&... args)
-{
-    std::ostream_iterator<char> os(std::cerr);
-    std::format_to(os, "Assertion failed at {}:{} in `{}`\nBecause '{}' {{{{{}}}}} != '{}' {{{{{}}}}}\n",
-                   file,
-                   line,
-                   func,
-                   left,
-                   detail::string_repr(left_value).c_str(), right, detail::string_repr(right_value).c_str());
-
-    std::format_to(os, fmt, std::forward<Args>(args)...);
-    std::format_to(os, "\n");
-    throw std::runtime_error("GEL assertion failure");
-}
-
-template <typename... Args>
-[[noreturn]]
-#ifdef _MSC_VER
-__declspec(noinline)
-#else
-__attribute__((noinline))
-#endif
-void gel_assert_neq_failure(
-    const char* file,
-    const int line,
-    const char* func,
-    const char* left,
-    const char* right,
-    auto left_value,
-    auto right_value,
-    std::format_string<Args...>&& fmt,
-    Args&&... args)
-{
-    std::ostream_iterator<char> os(std::cerr);
-    std::format_to(os, "Assertion failed at {}:{} in `{}`\nBecause '{}' {{{{{}}}}} == '{}' {{{{{}}}}}\n",
-                   file,
-                   line,
-                   func,
-                   left,
-                   detail::string_repr(left_value).c_str(), right, detail::string_repr(right_value).c_str());
-    std::format_to(os, fmt, std::forward<Args>(args)...);
-    std::format_to(os, "\n");
-    throw std::runtime_error("GEL assertion failure");
-}
-
-template <typename Predicate, typename... Args>
-auto gel_assert_impl(Predicate&& p, auto expr, auto file, auto line, auto func, std::format_string<Args...>&& fmt = "",
-                     Args&&... args) -> void
-{
-    [[unlikely]]
-    if (!p) {
-        gel_assert_failure(file, line, func, expr, std::forward<decltype(fmt)>(fmt), std::forward<Args>(args)...);
+    {
+        std::stringstream ss;
+        ss << t;
+        return ss.str();
     }
-}
 
-template <typename Predicate, typename... Args>
-auto gel_assert_false_impl(Predicate&& p, auto expr, auto file, auto line, auto func,
-                           std::format_string<Args...>&& fmt = "",
-                           Args&&... args) -> void
-{
-    [[unlikely]]
-    if (p) {
-        gel_assert_false_failure(file, line, func, expr, std::forward<decltype(fmt)>(fmt), std::forward<Args>(args)...);
+    template<typename T> std::string string_repr(T&& t)
+    {
+        return "?";
     }
-}
 
-template <typename Left, typename Right, typename... Args>
-auto gel_assert_eq_impl(Left&& l, Right&& r, auto expr_l, auto expr_r, auto file, auto line, auto func,
-                        std::format_string<Args...>&& fmt = "",
-                        Args&&... args) -> void requires detail::has_eq<Right, Left>
-{
-    [[unlikely]]
-    if (l != r) {
-        gel_assert_eq_failure(file, line, func, expr_l, expr_r, l, r, std::forward<decltype(fmt)>(fmt),
-                              std::forward<Args>(args)...);
-    }
-}
+#ifdef __GNUG__
+#define IGNORE_WFORMAT _Pragma("GCC diagnostic ignored \"-Wformat-security\"")
+#else
+#define IGNORE_WFORMAT
+#endif
 
-template <typename Left, typename Right, typename... Args>
-auto gel_assert_neq_impl(Left&& l, Right&& r, auto expr_l, auto expr_r, auto file, auto line, auto func,
-                         std::format_string<Args...>&& fmt = "",
-                         Args&&... args) -> void requires detail::has_eq<Right, Left>
-{
-    [[unlikely]]
-    if (l == r) {
-        gel_assert_neq_failure(file, line, func, expr_l, expr_r, l, r, std::forward<decltype(fmt)>(fmt),
-                               std::forward<Args>(args)...);
+#ifdef _MSC_VER
+    __declspec(noinline)
+#else
+    __attribute__((noinline))
+#endif
+    void
+    gel_assert_failure(const char* file, const int line, auto func, const char* expr, const char* fmt, auto... args)
+    {
+        fprintf(stderr, "Assertion failed at %s:%d in `%s`\nBecause '%s' is false\n", file, line, func, expr);
+        IGNORE_WFORMAT
+        fprintf(stderr, fmt, args...);
+        fprintf(stderr, "\n");
+        throw std::runtime_error("GEL assertion failure");
     }
-}
-}
+
+#ifdef _MSC_VER
+    __declspec(noinline)
+#else
+    __attribute__((noinline))
+#endif
+    void
+    gel_assert_false_failure(const char* file, const int line, auto func, const char* expr, const char* fmt,
+                             auto... args)
+    {
+        fprintf(stderr, "Assertion failed at %s:%d in `%s`\nBecause '%s' is true\n", file, line, func, expr);
+        IGNORE_WFORMAT
+        fprintf(stderr, fmt, args...);
+        fprintf(stderr, "\n");
+        throw std::runtime_error("GEL assertion failure");
+    }
+
+#ifdef _MSC_VER
+    __declspec(noinline)
+#else
+    __attribute__((noinline))
+#endif
+    void
+    gel_assert_eq_failure(const char* file, const int line, const char* func, const char* left, const char* right,
+                          auto left_value, auto right_value, const char* fmt, auto... args)
+    {
+        fprintf(stderr, "Assertion failed at %s:%d in `%s`\nBecause '%s' {{%s}} != '%s' {{%s}}\n", file, line, func,
+                left, string_repr(left_value).c_str(), right, string_repr(right_value).c_str());
+        IGNORE_WFORMAT
+        fprintf(stderr, fmt, args...);
+        fprintf(stderr, "\n");
+        throw std::runtime_error("GEL assertion failure");
+    }
+
+#ifdef _MSC_VER
+    __declspec(noinline)
+#else
+    __attribute__((noinline))
+#endif
+    void
+    gel_assert_neq_failure(const char* file, const int line, const char* func, const char* left, const char* right,
+                           auto left_value, auto right_value, const char* fmt, auto... args)
+    {
+        fprintf(stderr, "Assertion failed at %s:%d in `%s`\nBecause '%s' {{%s}} == '%s' {{%s}}\n", file, line, func,
+                left, string_repr(left_value).c_str(), right, string_repr(right_value).c_str());
+        IGNORE_WFORMAT
+        fprintf(stderr, fmt, args...);
+        fprintf(stderr, "\n");
+        throw std::runtime_error("GEL assertion failure");
+    }
+
+    template<typename Predicate, typename... Args>
+    auto gel_assert_impl(Predicate&& p, auto expr, auto file, auto line, auto func, Args... args) -> void
+    {
+        [[unlikely]]
+        if (!p) {
+            gel_assert_failure(file, line, func, expr, args...);
+        }
+    }
+
+    template<typename Predicate, typename... Args>
+    auto gel_assert_false_impl(Predicate&& p, auto expr, auto file, auto line, auto func, Args... args) -> void
+    {
+        [[unlikely]]
+        if (p) {
+            gel_assert_false_failure(file, line, func, expr, args...);
+        }
+    }
+
+    template<typename Left, typename Right, typename... Args>
+    auto gel_assert_eq_impl(Left&& l, Right&& r, auto expr_l, auto expr_r, auto file, auto line, auto func,
+                            Args... args) -> void
+    requires has_eq<Right, Left>
+    {
+        [[unlikely]]
+        if (l != r) {
+            gel_assert_eq_failure(file, line, func, expr_l, expr_r, l, r, args...);
+        }
+    }
+
+    template<typename Left, typename Right, typename... Args>
+    auto gel_assert_neq_impl(Left&& l, Right&& r, auto expr_l, auto expr_r, auto file, auto line, auto func,
+                             Args... args) -> void
+    requires has_eq<Right, Left>
+    {
+        [[unlikely]]
+        if (l == r) {
+            gel_assert_neq_failure(file, line, func, expr_l, expr_r, l, r, args...);
+        }
+    }
+} // namespace Util::Assert::detail
 
 /// @brief Assertion macro
-/// @details If the predicate is false, throws an std::runtime_error. Can be given a format string.
-/// @code
-/// auto i = 1;
-/// auto j = 1;
-/// GEL_ASSERT(i == j, "math is broken because {} is not equal to itself", i);
-/// @endcode
-#define GEL_ASSERT(pred, ...) do { ::Util::Assert::detail::gel_assert_impl((pred), #pred, __FILE__, __LINE__, __func__ __VA_OPT__(,) __VA_ARGS__); } while(false)
-
-/// @brief Assertion macro
-/// @details If the predicate is true, throws an std::runtime_error. Can be given a format string.
+/// @details If pred is false, throws an std::runtime_error. Can be given a C-style format string.
 /// @code
 /// auto i = 1;
 /// auto j = 2;
-/// GEL_ASSERT_FALSE(i == j, "math is broken because {} is equal to {}", i, j);
+/// GEL_ASSERT_FALSE(i == j, "math is broken because %d is equal to %d", i, j);
 /// @endcode
-#define GEL_ASSERT_FALSE(pred, ...) do { ::Util::Assert::detail::gel_assert_false_impl((pred), #pred, __FILE__, __LINE__, __func__ __VA_OPT__(,) __VA_ARGS__); } while(false)
-
+#define GEL_ASSERT(pred, ...)                                                                                          \
+    do {                                                                                                               \
+        ::Util::Assert::detail::gel_assert_impl((pred), #pred, __FILE__, __LINE__, __func__, "" __VA_ARGS__);          \
+    }                                                                                                                  \
+    while (false)
 
 /// @brief Assertion macro
-/// @details If left is not equal to right, throws an std::runtime_error. Can be given a format string.
+/// @details If pred is true, throws an std::runtime_error. Can be given a C-style format string.
+/// @code
+/// GEL_ASSERT(1 == 1, "math is broken");
+/// @endcode
+#define GEL_ASSERT_FALSE(pred, ...)                                                                                    \
+    do {                                                                                                               \
+        ::Util::Assert::detail::gel_assert_false_impl((pred), #pred, __FILE__, __LINE__, __func__, "" __VA_ARGS__);    \
+    }                                                                                                                  \
+    while (false)
+
+/// @brief Assertion macro
+/// @details If left is not equal to right, throws an std::runtime_error. Can be given a C-style format string.
 /// @code
 /// auto i = 1;
 /// auto j = 1;
 /// GEL_ASSERT_EQ(i, j, "math is broken");
 /// @endcode
-#define GEL_ASSERT_EQ(left, right, ...) do { ::Util::Assert::detail::gel_assert_eq_impl((left), (right), #left, #right, __FILE__, __LINE__, __func__ __VA_OPT__(,) __VA_ARGS__); } while(false)
+#define GEL_ASSERT_EQ(left, right, ...)                                                                                \
+    do {                                                                                                               \
+        ::Util::Assert::detail::gel_assert_eq_impl((left), (right), #left, #right, __FILE__, __LINE__, __func__,       \
+                                                   "" __VA_ARGS__);                                                    \
+    }                                                                                                                  \
+    while (false)
 
 /// @brief Assertion macro
-/// @details If left is equal to right, throws an std::runtime_error. Can be given a format string.
+/// @details If left is equal to right, throws an std::runtime_error. Can be given a C-style format string.
 /// @code
 /// auto i = 1;
 /// auto j = 2;
 /// GEL_ASSERT_NEQ(1, 2, "math is broken");
 /// @endcode
-#define GEL_ASSERT_NEQ(left, right, ...) do { ::Util::Assert::detail::gel_assert_neq_impl((left), (right), #left, #right, __FILE__, __LINE__, __func__ __VA_OPT__(,) __VA_ARGS__); } while(false)
+#define GEL_ASSERT_NEQ(left, right, ...)                                                                               \
+    do {                                                                                                               \
+        ::Util::Assert::detail::gel_assert_neq_impl((left), (right), #left, #right, __FILE__, __LINE__, __func__,      \
+                                                    "" __VA_ARGS__);                                                   \
+    }                                                                                                                  \
+    while (false)
 
-#endif //GEL_ASSERT_H
+#endif // GEL_ASSERT_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_subdirectory(CGLA-mat)
 add_subdirectory(CGLA-simple)
 add_subdirectory(CGLA-vec)
 add_subdirectory(Geometry-kdtree)
+add_subdirectory(Util-Assert)
 # The following two rely on key input in order to exit
 #add_subdirectory(CGLA-ogl)
 #add_subdirectory(GLGraphics-console)

--- a/src/test/Util-Assert/Assert_test.cpp
+++ b/src/test/Util-Assert/Assert_test.cpp
@@ -1,0 +1,23 @@
+//
+// Created by arkeo on 7/2/25.
+//
+
+#include <GEL/Util/Assert.h>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+
+TEST_CASE("Assert doesn't fail to compile")
+{
+    GEL_ASSERT(true);
+    GEL_ASSERT(true, "Hello");
+    GEL_ASSERT(true, "Hello %s", "world");
+    GEL_ASSERT_FALSE(false);
+    GEL_ASSERT_FALSE(false, "Hello");
+    GEL_ASSERT_FALSE(false, "Hello %s", "world");
+    GEL_ASSERT_EQ(true, true);
+    GEL_ASSERT_EQ(true, true, "Hello");
+    GEL_ASSERT_EQ(true, true, "Hello %s", "world");
+    GEL_ASSERT_NEQ(true, false);
+    GEL_ASSERT_NEQ(true, false, "Hello");
+    GEL_ASSERT_NEQ(true, false, "Hello %s", "world");
+}

--- a/src/test/Util-Assert/CMakeLists.txt
+++ b/src/test/Util-Assert/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.30)
+
+add_executable(Assert_test Assert_test.cpp)
+target_include_directories(Assert_test PRIVATE ../.. ${DOCTEST_INCLUDE_DIR})
+set_target_properties(Assert_test PROPERTIES
+        CXX_STANDARD 20)
+target_link_libraries(Assert_test GEL nanobench)
+
+doctest_discover_tests(Assert_test TEST_PREFIX "Assert.")


### PR DESCRIPTION
This modifies the addition in #87 to an earlier, worse design I had that is compatible with GCC 11. If the minimum GCC version is bumped to GCC 13 (Ubuntu 24.04), commit 1f5c07fe5206a68c27dd4538e28829f1dc310d00 can be reverted and every usage of the macro has to be updated to replace %s with {}.

I also added a test this time so I don't notice the mistake right after merging.