### PR TITLE
Add coverage info to CI runners

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,13 +27,15 @@ jobs:
     #   run: vcpkg install glfw3
 
     - if: startsWith(matrix.os, 'ubuntu')
-      name: Add GLFW to Ubuntu environment
-      run: sudo apt-get install libxi-dev libxcursor-dev libxinerama-dev libxrandr-dev libgl-dev libglu-dev
+      name: Add GLFW and coverage tools to Ubuntu environment
+      run: |
+        sudo apt-get install libxi-dev libxcursor-dev libxinerama-dev libxrandr-dev libgl-dev libglu-dev
+        sudo apt-get install lcov
       # libglfw3-dev
 
-    # - if: startsWith(matrix.os, 'macOS')
-    #   name: Add GLFW to MacOS environment
-    #   run: brew install glfw
+      # - if: startsWith(matrix.os, 'macOS')
+      #   name: Add GLFW to MacOS environment
+      #   run: brew install glfw
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -45,24 +47,44 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{github.workspace}}/build_${{matrix.os}}
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # Note the current convention is to use the -S and -B options here to specify source
+      # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE 
+      run: |
+        if [[ "${{ matrix.os }}" == ubuntu* ]]; then
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="--coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage"
+        else
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        fi
 
     - name: Build
       working-directory: ${{github.workspace}}/build_${{matrix.os}}
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . -v --config $BUILD_TYPE
+      run: cmake --build . -v --config $BUILD_TYPE -j 3
 
     - name: Test
       working-directory: ${{github.workspace}}/build_${{matrix.os}}
       shell: bash
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE -j 2
+
+    - name: Generate coverage report
+      if: startsWith(matrix.os, 'ubuntu')
+      working-directory: ${{github.workspace}}/build_${{matrix.os}}
+      run: |
+        lcov --capture --directory . --output-file coverage.info
+        lcov --remove coverage.info '/usr/*' --output-file coverage.info
+        lcov --list coverage.info
       
+    - name: Upload coverage report
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ matrix.os }}
+        path: ${{github.workspace}}/build_${{matrix.os}}/coverage.info
+
     - name: Packaging
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This adds code coverage information to the CI for Linux platforms. I also changed the build and test commands to use extra cores so CI builds should hopefully run faster.

Note that the coverage can only check files that have been included within the test binaries. That means that files will be missing from the coverage report until we end up adding enough tests that transitively include every file inside GEL.

Example coverage report:
```
Summary coverage rate:
  lines......: 48.7% (2553 of 5240 lines)
  functions..: 36.5% (279 of 764 functions)
  branches...: no data found
                                               |Lines      |Functions|Branches  
Filename                                       |Rate    Num|Rate  Num|Rate   Num
================================================================================
[/home/runner/work/GEL/GEL/]
build_ubuntu-24.04/_de...-src/doctest/doctest.h|48.6%   582| 0.0%  62|    -    0
build_ubuntu-24.04/_de...rc/include/nanobench.h|39.3%   430| 0.0%  96|    -    0
src/GEL/CGLA/ArithMatFloat.h                   |26.7%    60| 0.0%  12|    -    0
src/GEL/CGLA/ArithQuat.h                       |    -     0|    -   0|    -    0
src/GEL/CGLA/ArithSqMat2x2Float.h              |50.0%     4| 0.0%   1|    -    0
src/GEL/CGLA/ArithSqMat3x3Float.h              |    -     0|    -   0|    -    0
src/GEL/CGLA/ArithSqMat4x4Float.cpp            | 6.5%    92| 0.0%   3|    -    0
src/GEL/CGLA/ArithSqMat4x4Float.h              | 122%     9| 0.0%   2|    -    0
src/GEL/CGLA/ArithSqMatFloat.h                 |25.0%    12| 0.0%   2|    -    0
src/GEL/CGLA/ArithVec.h                        | 8.2%    49| 0.0%   4|    -    0
src/GEL/CGLA/ArithVec2Float.cpp                |40.0%     5| 0.0%   2|    -    0
src/GEL/CGLA/ArithVec2Float.h                  | 200%     2|    -   0|    -    0
src/GEL/CGLA/ArithVec3Float.cpp                |40.0%    20| 0.0%   8|    -    0
src/GEL/CGLA/ArithVec3Float.h                  | 133%     3|    -   0|    -    0
src/GEL/CGLA/ArithVecFloat.h                   | 220%     5| 0.0%   8|    -    0
src/GEL/CGLA/CGLA-util.h                       | 0.0%     4|    -   0|    -    0
src/GEL/CGLA/ExceptionStandard.h               |    -     0|    -   0|    -    0
src/GEL/CGLA/Mat2x2d.h                         |    -     0|    -   0|    -    0
src/GEL/CGLA/Mat2x2f.h                         |    -     0|    -   0|    -    0
src/GEL/CGLA/Mat2x3f.h                         | 0.0%     2|    -   0|    -    0
src/GEL/CGLA/Mat3x3d.h                         |    -     0|    -   0|    -    0
src/GEL/CGLA/Mat3x3f.h                         | 0.0%     1|    -   0|    -    0
src/GEL/CGLA/Mat4x4f.cpp                       |    -     0|    -   0|    -    0
src/GEL/CGLA/Quatf.h                           |    -     0|    -   0|    -    0
src/GEL/CGLA/Vec2f.h                           | 0.0%     1|    -   0|    -    0
src/GEL/CGLA/Vec2i.cpp                         |50.0%     2| 0.0%   1|    -    0
src/GEL/CGLA/Vec3f.cpp                         |    -     0|    -   0|    -    0
src/GEL/CGLA/Vec3i.cpp                         |50.0%     8| 0.0%   3|    -    0
src/GEL/CGLA/Vec3usi.h                         | 0.0%     1|    -   0|    -    0
src/GEL/CGLA/Vec4f.h                           |    -     0|    -   0|    -    0
src/GEL/CGLA/eigensolution.cpp                 |30.0%    20| 0.0%   2|    -    0
src/GEL/CGLA/gel_rand.cpp                      |50.0%     6| 0.0%   2|    -    0
src/GEL/CGLA/statistics.cpp                    |85.7%     7| 0.0%   1|    -    0
src/GEL/CGLA/statistics.h                      | 150%     4| 0.0%   1|    -    0
src/GEL/Geometry/IndexedFaceSet.h              |    -     0|    -   0|    -    0
src/GEL/Geometry/KDTree.h                      |12.9%   132| 0.0%  11|    -    0
src/GEL/Geometry/QEM.h                         |    -     0|    -   0|    -    0
src/GEL/HMesh/AttributeVector.h                | 0.0%     1|    -   0|    -    0
src/GEL/HMesh/Circulators.h                    | 0.0%     3|    -   0|    -    0
src/GEL/HMesh/ConnectivityKernel.cpp           | 4.5%    22| 0.0%   1|    -    0
src/GEL/HMesh/ConnectivityKernel.h             | 3.7%    27|    -   0|    -    0
src/GEL/HMesh/ItemID.h                         | 0.0%     4|    -   0|    -    0
src/GEL/HMesh/ItemVector.h                     |58.3%    36| 0.0%  19|    -    0
src/GEL/HMesh/Iterators.h                      | 0.0%     4|    -   0|    -    0
src/GEL/HMesh/Manifold.cpp                     |74.0%    73| 0.0%   6|    -    0
src/GEL/HMesh/Manifold.h                       |91.7%    48| 0.0%  10|    -    0
src/GEL/HMesh/Walker.h                         | 0.0%     5|    -   0|    -    0
src/GEL/HMesh/cleanup.cpp                      |76.2%    21| 0.0%   1|    -    0
src/GEL/HMesh/refine_edges.cpp                 |    -     0|    -   0|    -    0
src/GEL/HMesh/triangulate.cpp                  |    -     0|    -   0|    -    0
src/GEL/Util/Assert.h                          |20.0%     5|    -   0|    -    0
src/GEL/Util/AttribVec.h                       |68.8%    16| 0.0%   5|    -    0
src/GEL/Util/Timer.h                           |20.0%     5| 0.0%   1|    -    0
src/test/CGLA-covariance/covariance_test.cpp   |10.0%    20| 0.0%   1|    -    0
src/test/CGLA-mat/mat_test.cpp                 | 5.9%    51| 0.0%   2|    -    0
src/test/CGLA-simple/simple_test.cpp           | 120%     5| 0.0%   2|    -    0
src/test/CGLA-vec/vec_test.cpp                 | 0.2%   659| 0.0%   1|    -    0
src/test/Geometry-kdtree/kdtree-test.cpp       | 5.0%    40| 0.0%   2|    -    0
src/test/Manifold/Manifold_test.cpp            |13.3%    45| 0.0%   6|    -    0
src/test/Util-Assert/Assert_test.cpp           |50.0%     2| 0.0%   1|    -    0
================================================================================
                                         Total:|29.9%  2553| 0.0% 279|    -    0
```

Due to how templates work, as well as running the CI on a release build, some of the coverage information might be a bit unexpected. For example, entire files may appear to have "no code". 