### PR TITLE
Add split_vertex, deprecate slit_vertex and replace with slit_one_ring

### DIFF
--- a/src/test/Manifold/CMakeLists.txt
+++ b/src/test/Manifold/CMakeLists.txt
@@ -11,4 +11,4 @@ set_target_properties(Manifold_test PROPERTIES
 target_include_directories(Manifold_test PRIVATE ${GEL_INCLUDE_DIR} ${DOCTEST_INCLUDE_DIR})
 target_link_libraries(Manifold_test GEL nanobench)
 
-add_test(NAME GEL.Test.Manifold COMMAND Manifold_test)
+doctest_discover_tests(Manifold_test TEST_PREFIX "Manifold.")

--- a/src/test/Manifold/Manifold_test.cpp
+++ b/src/test/Manifold/Manifold_test.cpp
@@ -267,7 +267,7 @@ HMesh::Manifold create_rectangular_manifold(const size_t x_size, const size_t y_
 
 // Test cases
 
-TEST_SUITE("Slit")
+TEST_SUITE("slit_one_ring")
 {
     TEST_CASE("center")
     {
@@ -292,7 +292,7 @@ TEST_SUITE("Slit")
     }
 }
 
-TEST_SUITE("Split")
+TEST_SUITE("split_vertex")
 {
     TEST_CASE("inner")
     {
@@ -473,6 +473,121 @@ TEST_SUITE("Split")
     }
 }
 
+TEST_SUITE("Misc.")
+{
+    TEST_CASE("Borderline non-manifold")
+    {
+        // This tests a case where a mesh is not technically manifold but this case should still be
+        // supported.
+        // We first create a grid of 2x2 faces
+        auto m = create_rectangular_manifold(3,3);
+        // We check that this is a single connected component
+        CHECK_EQ(HMesh::connected_components(m).size(), 1);
+        // We now remove two diagonally opposite faces
+        m.remove_face(HMesh::FaceID(0));
+        m.remove_face(HMesh::FaceID(3));
+        // We check that there is stil a single connected component since
+        // the two remaining faces are connected by a single vertex
+        CHECK_EQ(HMesh::connected_components(m).size(), 1);
+        // There is also just one boundary curve
+        CHECK_EQ(HMesh::count_boundary_curves(m), 1);
+        // Final validation.
+        CHECK(validate_manifold(m));
+    }
+
+    TEST_CASE("Two tetrahedra share a vertex")
+    {
+        // This is a simple case where two tetra share a vertex. The important thing
+        // to validate is that we get two connected components and not just one
+        std::vector<CGLA::Vec3d> pts = {
+            CGLA::Vec3d(0,0,0), CGLA::Vec3d(1,0,0), CGLA::Vec3d(0,1,0),
+            CGLA::Vec3d(0,0,0.5),
+            CGLA::Vec3d(0,0,1), CGLA::Vec3d(1,0,1), CGLA::Vec3d(0,1,1)
+        };
+        auto m = HMesh::Manifold();
+        m.add_face({pts[0],pts[2], pts[1]});
+        m.add_face({pts[0],pts[1], pts[3]});
+        m.add_face({pts[0],pts[3], pts[2]});
+        m.add_face({pts[1],pts[2], pts[3]});
+        m.add_face({pts[4],pts[5], pts[6]});
+        m.add_face({pts[4],pts[3], pts[5]});
+        m.add_face({pts[4],pts[6], pts[3]});
+        m.add_face({pts[3],pts[6], pts[5]});
+        HMesh::stitch_mesh(m, 1e-6);
+        // THere must be two connected components
+        CHECK_EQ(HMesh::connected_components(m).size(), 2);
+        // no boundary curves
+        CHECK_EQ(HMesh::count_boundary_curves(m), 0);
+        // Final validation.
+        CHECK(validate_manifold(m));
+    }
+    TEST_CASE("Non-manifold edge")
+    {
+        // This is a simple case where three triangles share an edge
+        // this cannot be stitched, so the best to hope for is that we
+        // get two connected components, i.e. two out of three triangles
+        // are stitched,
+        std::vector<CGLA::Vec3d> pts = {
+            CGLA::Vec3d(0,0,0),
+            CGLA::Vec3d(0,0,1),
+            CGLA::Vec3d(1,0,0),
+            CGLA::Vec3d(-1,0,0),
+            CGLA::Vec3d(0,1,0)
+        };
+        auto m = HMesh::Manifold();
+        m.add_face({pts[0],pts[1], pts[2]});
+        m.add_face({pts[1],pts[0], pts[3]});
+        m.add_face({pts[0],pts[1], pts[4]});
+
+        HMesh::stitch_mesh(m, 1e-6);
+        // THere must be two connected components
+        CHECK_EQ(HMesh::connected_components(m).size(), 2);
+        // no boundary curves
+        CHECK_EQ(HMesh::count_boundary_curves(m), 2);
+        // Final validation.
+        CHECK(validate_manifold(m));
+    }
+    TEST_CASE("Strange fin")
+    {
+        // We start by forming a mesh consisting of two triangles.
+        std::vector<CGLA::Vec3d> pts = {
+            CGLA::Vec3d(0,0,0),
+            CGLA::Vec3d(0,1,0),
+            CGLA::Vec3d(-1,0,0),
+            CGLA::Vec3d(1,0,0)
+        };
+        auto m = HMesh::Manifold();
+        auto f0 = m.add_face({pts[0],pts[1], pts[2]});
+        auto f1 = m.add_face({pts[1],pts[0], pts[3]});
+
+        HMesh::stitch_mesh(m, 1e-6);
+        // THere must be a single connected components
+        CHECK_EQ(HMesh::connected_components(m).size(), 1);
+        // one boundary curve
+        CHECK_EQ(HMesh::count_boundary_curves(m), 1);
+        // Final validation.
+        CHECK(validate_manifold(m));
+
+        // Now extrude the shared edge.
+        HMesh::HalfEdgeID h0;
+        for (auto h: m.incident_halfedges(f0)) {
+            if (m.walker(h).opp().face() != HMesh::InvalidFaceID) {
+                h0 = h;
+                break;
+            }
+        }
+        HMesh::HalfEdgeSet hset = {h0};
+        auto extruded_faces = HMesh::extrude_halfedge_set(m, hset);
+        auto f = *(extruded_faces.begin());
+        // which we cannot merge since it would result in valence 1 vertices.
+        bool can_we_merge = m.merge_faces(f, h0);
+        CHECK_FALSE(can_we_merge);
+
+        // Since we have two valence two vertices, we cannot validate that the mesh
+        // is fully valid since the test is too picky for that.
+    }
+}
+
 TEST_CASE("Benchmark manifold")
 {
     SUBCASE("10 x 10")
@@ -503,117 +618,6 @@ TEST_CASE("Benchmark manifold")
         CHECK(validate_manifold(m));
         });
     }
-    SUBCASE("Borderline non-manifold")
-    {
-        // This tests a case where a mesh is not technically manifold but this case should still be
-        // supported.
-        // We first create a grid of 2x2 faces
-        auto m = create_rectangular_manifold(3,3);
-        // We check that this is a single connected component
-        CHECK(HMesh::connected_components(m).size()==1);
-        // We now remove two diagonally opposite faces
-        m.remove_face(HMesh::FaceID(0));
-        m.remove_face(HMesh::FaceID(3));
-        // We check that there is stil a single connected component since
-        // the two remaining faces are connected by a single vertex
-        CHECK(HMesh::connected_components(m).size()==1);
-        // There is also just one boundary curve
-        CHECK(HMesh::count_boundary_curves(m)==1);
-        // Final validation.
-        CHECK(validate_manifold(m));
-    }
-    SUBCASE("Two tetrahedra share a vertex")
-    {
-        // This is a simple case where two tetra share a vertex. The important thing
-        // to validate is that we get two connected components and not just one
-        std::vector<CGLA::Vec3d> pts = {
-            CGLA::Vec3d(0,0,0), CGLA::Vec3d(1,0,0), CGLA::Vec3d(0,1,0),
-            CGLA::Vec3d(0,0,0.5),
-            CGLA::Vec3d(0,0,1), CGLA::Vec3d(1,0,1), CGLA::Vec3d(0,1,1)
-        };
-        auto m = HMesh::Manifold();
-        m.add_face({pts[0],pts[2], pts[1]});
-        m.add_face({pts[0],pts[1], pts[3]});
-        m.add_face({pts[0],pts[3], pts[2]});
-        m.add_face({pts[1],pts[2], pts[3]});
-        m.add_face({pts[4],pts[5], pts[6]});
-        m.add_face({pts[4],pts[3], pts[5]});
-        m.add_face({pts[4],pts[6], pts[3]});
-        m.add_face({pts[3],pts[6], pts[5]});
-        HMesh::stitch_mesh(m, 1e-6);
-        // THere must be two connected components
-        CHECK(HMesh::connected_components(m).size()==2);
-        // no boundary curves
-        CHECK(HMesh::count_boundary_curves(m)==0);
-        // Final validation.
-        CHECK(validate_manifold(m));
-    }
-    SUBCASE("Non-manifold edge")
-    {
-        // This is a simple case where three triangles share an edge
-        // this cannot be stitched, so the best to hope for is that we
-        // get two connected components, i.e. two out of three triangles
-        // are stitched,
-        std::vector<CGLA::Vec3d> pts = {
-            CGLA::Vec3d(0,0,0),
-            CGLA::Vec3d(0,0,1),
-            CGLA::Vec3d(1,0,0),
-            CGLA::Vec3d(-1,0,0),
-            CGLA::Vec3d(0,1,0)
-        };
-        auto m = HMesh::Manifold();
-        m.add_face({pts[0],pts[1], pts[2]});
-        m.add_face({pts[1],pts[0], pts[3]});
-        m.add_face({pts[0],pts[1], pts[4]});
-
-        HMesh::stitch_mesh(m, 1e-6);
-        // THere must be two connected components
-        CHECK(HMesh::connected_components(m).size()==2);
-        // no boundary curves
-        CHECK(HMesh::count_boundary_curves(m)==2);
-        // Final validation.
-        CHECK(validate_manifold(m));
-    }
-    SUBCASE("Strange fin")
-    {
-        // We start by forming a mesh consisting of two triangles.
-        std::vector<CGLA::Vec3d> pts = {
-            CGLA::Vec3d(0,0,0),
-            CGLA::Vec3d(0,1,0),
-            CGLA::Vec3d(-1,0,0),
-            CGLA::Vec3d(1,0,0)
-        };
-        auto m = HMesh::Manifold();
-        auto f0 = m.add_face({pts[0],pts[1], pts[2]});
-        auto f1 = m.add_face({pts[1],pts[0], pts[3]});
-
-        HMesh::stitch_mesh(m, 1e-6);
-        // THere must be a single connected components
-        CHECK(HMesh::connected_components(m).size()==1);
-        // one boundary curve
-        CHECK(HMesh::count_boundary_curves(m)==1);
-        // Final validation.
-        CHECK(validate_manifold(m));
-
-        // Now extrude the shared edge.
-        HMesh::HalfEdgeID h0;
-        for (auto h: m.incident_halfedges(f0)) {
-            if (m.walker(h).opp().face() != HMesh::InvalidFaceID) {
-                h0 = h;
-                break;
-            }
-        }
-        HMesh::HalfEdgeSet hset = {h0};
-        auto extruded_faces = HMesh::extrude_halfedge_set(m, hset);
-        auto f = *(extruded_faces.begin());
-        // which we cannot merge since it would result in valence 1 vertices.
-        bool can_we_merge = m.merge_faces(f, h0);
-        CHECK(can_we_merge == false);
-
-        // Since we have two valence two vertices, we cannot validate that the mesh
-        // is fully valid since the test is too picky for that.
-    }
-
     // // If Manifold::cleanup can be improved to use constant space, this should be able to run on the CI
     // // This would be the practical maximum for the largest inputs people would pass
     // SUBCASE("10000x x 10000")


### PR DESCRIPTION
This PR adds split_vertex which performs a slit_one_ring operation (formerly slit_vertex) and then fills the created gap which is valid in a few additional cases compared to slit_one_ring. It also adds two new private functions to cleanly perform this operation.

Also see #93 