### PR TITLE
Stop shipping doctest in GEL installations

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -7,14 +7,16 @@ FetchContent_Declare(
     nanobench
     GIT_REPOSITORY https://github.com/martinus/nanobench.git
     GIT_TAG v4.1.0
-    GIT_SHALLOW TRUE)
+    GIT_SHALLOW TRUE
+    EXCLUDE_FROM_ALL)
 
 # Add testing library
 FetchContent_Declare(
     doctest
     GIT_REPOSITORY https://github.com/doctest/doctest.git
     GIT_TAG v2.4.12
-    GIT_SHALLOW TRUE)
+    GIT_SHALLOW TRUE
+    EXCLUDE_FROM_ALL)
 
 FetchContent_MakeAvailable(nanobench)
 # # Add nanobench to a project with:


### PR DESCRIPTION
It seems that by default FetchContent adds included targets from the dependency to our own install targets which means that we are unintentionally installing doctest to the include directory of downstream users. This is naturally unnecessary.